### PR TITLE
Fix parsing fraction with exponent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "json5format"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json5format"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
   "Rich Kadel <richkadel@google.com>",
   "David Tamas-Parris <davidatp@google.com>",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,9 +65,18 @@ lazy_static! {
                 (?:(?:
                     NaN|
                     Infinity|
-                    (?:0[xX][0-9a-fA-F]+)|     # hexadecimal notation
-                    (?:[0-9]+[eE][+-]?[0-9]+)| # exponent notation
-                    (?:[0-9]*\.[0-9]+)         # decimal notation
+
+                    # hexadecimal notation
+                    (?:0[xX][0-9a-fA-F]+)|
+
+                    # decimal exponent notation
+                    (?:(?:0|(?:[1-9][0-9]*))?\.[0-9]+[eE][+-]?[0-9]+)|
+
+                    # integer exponent notation with optional trailing decimal point
+                    (?:(?:0|(?:[1-9][0-9]*))\.?[eE][+-]?[0-9]+)|
+
+                    # decimal notation
+                    (?:(?:0|(?:[1-9][0-9]*))?\.[0-9]+)
                 )\b)|
 
                 # Capture integers, with an optional trailing decimal point.
@@ -79,7 +88,7 @@ lazy_static! {
                 # character.)
 
                 (?:
-                    [0-9]+(?:\.|\b)
+                    (?:0|(?:[1-9][0-9]*))(?:\.|\b)
                 )
             ))
         )"#;
@@ -1722,7 +1731,7 @@ expected_indicator:    {}
             non_string_primitive in
                 concat!(
                     r#"(null|true|false)|([-+]?(NaN|Infinity|(0[xX][0-9a-fA-F]+)"#,
-                    r#"|([0-9]+[eE][+-]?[0-9]+)|([0-9]*\.[0-9]+)|([0-9]+\.?)))"#
+                    r#"|((0|([1-9][0-9]*))?\.[0-9]+[eE][+-]?[0-9]+)|((0|([1-9][0-9]*))?\.[0-9]+)|((0|([1-9][0-9]*))\.?)))"#
                 ),
             ends_non_string_primitive in r#"(|([\s,\]\}]\PC*))"#,
         ) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,6 +109,19 @@ fn test_format_simple_objects() {
 }
 
 #[test]
+fn test_format_exponential() {
+    test_format(FormatTest {
+        input: r##"{ "exponential": 3.14e-8 }"##,
+        expected: r##"{
+    exponential: 3.14e-8,
+}
+"##,
+        ..Default::default()
+    })
+    .unwrap()
+}
+
+#[test]
 fn test_last_scope_is_array() {
     test_format(FormatTest {
         input: r##"{
@@ -744,9 +757,17 @@ fn test_parse_error_bad_non_string_primitive() {
         true,
         false,
 
+        0,
+        0.,
+        0.0,
+        0.000,
+        .0,
+        .000,
         12345,
+        12345.00000,
         12345.67890,
         12345.,
+        0.678900,
         .67890,
         1234e5678,
         1234E5678,
@@ -754,6 +775,12 @@ fn test_parse_error_bad_non_string_primitive() {
         1234E+5678,
         1234e-5678,
         1234E-5678,
+        12.34e5678,
+        1234.E5678,
+        .1234e+5678,
+        12.34E+5678,
+        1234.e-5678,
+        .1234E-5678,
         0xabc123ef,
         0Xabc123EF,
         NaN,
@@ -769,6 +796,12 @@ fn test_parse_error_bad_non_string_primitive() {
         -1234E+5678,
         -1234e-5678,
         -1234E-5678,
+        -12.34e5678,
+        -1234.E5678,
+        -.1234e+5678,
+        -12.34E+5678,
+        -1234.e-5678,
+        -.1234E-5678,
         -0xabc123ef,
         -0Xabc123EF,
         -NaN,
@@ -789,14 +822,41 @@ fn test_parse_error_bad_non_string_primitive() {
         +NaN,
         +Infinity,
 
-        123def,
         0x123def,
+        123def,
     ]
 }
 "##,
         error: Some(
-            "Parse error: 52:9: Unexpected token:
+            "Parse error: 73:9: Unexpected token:
         123def,
+        ^",
+        ),
+        ..Default::default()
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_parse_error_leading_zero() {
+    test_format(FormatTest {
+        input: r##"{
+    non_string_literals: [
+        0,
+        0.,
+        0.0,
+        0.000,
+        .0,
+        .000,
+        +0.678900,
+        -0.678900,
+        -01.67890,
+    ]
+}
+"##,
+        error: Some(
+            "Parse error: 11:9: Unexpected token:
+        -01.67890,
         ^",
         ),
         ..Default::default()


### PR DESCRIPTION
The JSON5 specification does say numeric values can include the
fraction part AND an exponent part, but the examples don't show this.
The parser should have handled them. This PR fixes that bug.

Fixes: #34