### PR TITLE
Clippy fixes + Clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,5 +23,7 @@ jobs:
       run: cargo fmt -- --check
     - name: Build
       run: cargo build --verbose
+    - name: Clippy
+      run: cargo clippy --all-targets -- -D warnings
     - name: Run tests
       run: cargo test --verbose

--- a/examples/formatjson5.rs
+++ b/examples/formatjson5.rs
@@ -29,7 +29,6 @@
 
 #![warn(missing_docs)]
 
-use anyhow;
 use anyhow::Result;
 use json5format::*;
 use std::fs;
@@ -67,7 +66,7 @@ fn format_documents(
     let format = Json5Format::with_options(options)?;
     for (index, parsed_document) in parsed_documents.iter().enumerate() {
         let filename = parsed_document.filename().as_ref().unwrap();
-        let bytes = format.to_utf8(&parsed_document)?;
+        let bytes = format.to_utf8(parsed_document)?;
         if replace {
             Opt::write_to_file(filename, &bytes)?;
         } else {
@@ -88,7 +87,7 @@ fn format_documents(
 fn main() -> Result<()> {
     let args = Opt::args();
 
-    if args.files.len() == 0 {
+    if args.files.is_empty() {
         return Err(anyhow::anyhow!("No files to format"));
     }
 
@@ -144,8 +143,8 @@ impl Opt {
         Self::from_args()
     }
 
-    fn from_stdin(mut buf: &mut String) -> Result<usize, io::Error> {
-        io::stdin().read_to_string(&mut buf)
+    fn from_stdin(buf: &mut String) -> Result<usize, io::Error> {
+        io::stdin().read_to_string(buf)
     }
 
     fn write_to_file(filename: &str, bytes: &[u8]) -> Result<(), io::Error> {
@@ -154,7 +153,7 @@ impl Opt {
             .truncate(true)
             .write(true)
             .open(filename)?
-            .write_all(&bytes)
+            .write_all(bytes)
     }
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -85,7 +85,7 @@ impl SubpathOptions {
                 new_options
             }
         };
-        if remaining_path.len() == 0 {
+        if remaining_path.is_empty() {
             subpath_options
         } else {
             (*subpath_options.borrow_mut())
@@ -102,7 +102,7 @@ impl SubpathOptions {
             self.subpath_options_by_name.get(name_or_star)
         };
         if let Some(subpath_options) = subpath_options_ref {
-            if remaining_path.len() == 0 {
+            if remaining_path.is_empty() {
                 Some(subpath_options.clone())
             } else {
                 (*subpath_options.borrow()).get_subpath_options(remaining_path)
@@ -213,13 +213,13 @@ impl Formatter {
 
     /// Appends the given string, indenting if required.
     pub fn append(&mut self, content: &str) -> Result<&mut Formatter, Error> {
-        if self.pending_indent && !content.starts_with("\n") {
+        if self.pending_indent && !content.starts_with('\n') {
             let spaces = self.depth * self.default_options.indent_by;
             self.bytes.extend_from_slice(" ".repeat(spaces).as_bytes());
             self.column = spaces + 1;
             self.pending_indent = false;
         }
-        if content.ends_with("\n") {
+        if content.ends_with('\n') {
             self.column = 1;
             self.bytes.extend_from_slice(content.as_bytes());
         } else {
@@ -244,7 +244,7 @@ impl Formatter {
     /// Outputs a newline (unless this is the first line), and sets the `pending_indent` flag to
     /// indicate the next non-blank line should be indented.
     pub fn start_next_line(&mut self) -> Result<&mut Formatter, Error> {
-        if self.bytes.len() > 0 {
+        if !self.bytes.is_empty() {
             self.append_newline()?;
         }
         self.pending_indent = true;
@@ -276,7 +276,7 @@ impl Formatter {
 
     fn format_comments_internal(
         &mut self,
-        comments: &Vec<Comment>,
+        comments: &[Comment],
         leading_blank_line: bool,
     ) -> Result<&mut Formatter, Error> {
         let mut previous: Option<&Comment> = None;
@@ -304,7 +304,7 @@ impl Formatter {
 
     pub fn format_comments(
         &mut self,
-        comments: &Vec<Comment>,
+        comments: &[Comment],
         is_first: bool,
     ) -> Result<&mut Formatter, Error> {
         self.format_comments_internal(comments, !is_first)
@@ -312,7 +312,7 @@ impl Formatter {
 
     pub fn format_trailing_comments(
         &mut self,
-        comments: &Vec<Comment>,
+        comments: &[Comment],
     ) -> Result<&mut Formatter, Error> {
         self.format_comments_internal(comments, true)
     }
@@ -377,7 +377,7 @@ impl Formatter {
             if is_first {
                 self.start_next_line()?;
             }
-            self.format_comments(&value.comments().before_value(), is_first)?;
+            self.format_comments(value.comments().before_value(), is_first)?;
         }
         if let Some(name) = name {
             self.append(&format!("{}: ", name))?;
@@ -406,7 +406,7 @@ impl Formatter {
     ) -> Result<&mut Formatter, Error> {
         self.format_scoped_value(
             None,
-            &mut *item.borrow_mut(),
+            &mut item.borrow_mut(),
             is_first,
             is_last,
             container_has_pending_comments,
@@ -422,7 +422,7 @@ impl Formatter {
     ) -> Result<&mut Formatter, Error> {
         self.format_scoped_value(
             Some(&property.name),
-            &mut *property.value.borrow_mut(),
+            &mut property.value.borrow_mut(),
             is_first,
             is_last,
             container_has_pending_comments,
@@ -431,7 +431,7 @@ impl Formatter {
 
     pub fn options_in_scope(&self) -> FormatOptions {
         match self.get_current_subpath_options() {
-            Some(subpath_options) => (*subpath_options.borrow()).options.clone(),
+            Some(subpath_options) => subpath_options.borrow().options.clone(),
             None => self.default_options.clone(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,7 @@
 //! * All other original spaces are removed.
 
 #![deny(missing_docs)]
+#![allow(clippy::len_zero)]
 
 #[macro_use]
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,9 +394,9 @@ impl Json5Format {
             let mut borrowed; // extend life of temporary
             let subpath_options = if path == "/" {
                 &mut document_root_options
-            } else if path.starts_with("/") {
+            } else if let Some(remaining) = path.strip_prefix('/') {
                 rc = document_root_options.get_or_create_subpath_options(
-                    &path[1..].split('/').collect::<Vec<_>>(),
+                    &remaining.split('/').collect::<Vec<_>>(),
                     &default_options,
                 );
                 borrowed = rc.borrow_mut();

--- a/src/options.rs
+++ b/src/options.rs
@@ -29,13 +29,13 @@ pub enum PathOption {
 impl PartialEq for PathOption {
     fn eq(&self, other: &Self) -> bool {
         use PathOption::*;
-        match (self, other) {
-            (&TrailingCommas(..), &TrailingCommas(..)) => true,
-            (&CollapseContainersOfOne(..), &CollapseContainersOfOne(..)) => true,
-            (&SortArrayItems(..), &SortArrayItems(..)) => true,
-            (&PropertyNameOrder(..), &PropertyNameOrder(..)) => true,
-            _ => false,
-        }
+        matches!(
+            (self, other),
+            (&TrailingCommas(..), &TrailingCommas(..))
+                | (&CollapseContainersOfOne(..), &CollapseContainersOfOne(..))
+                | (&SortArrayItems(..), &SortArrayItems(..))
+                | (&PropertyNameOrder(..), &PropertyNameOrder(..))
+        )
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,17 +14,12 @@ use {
     std::path::PathBuf,
 };
 
+#[derive(Default)]
 struct FormatTest<'a> {
     options: Option<FormatOptions>,
     input: &'a str,
     error: Option<&'a str>,
     expected: &'a str,
-}
-
-impl<'a> Default for FormatTest<'a> {
-    fn default() -> Self {
-        FormatTest { options: None, input: "", error: None, expected: "" }
-    }
 }
 
 fn try_test_format(test: FormatTest<'_>) -> Result<(), Error> {
@@ -1101,9 +1096,9 @@ See [fuchsia.dev](https://fuchsia.dev).
 fn test_options() {
     let options = FormatOptions { ..Default::default() };
     assert_eq!(options.indent_by, 4);
-    assert_eq!(options.trailing_commas, true);
-    assert_eq!(options.collapse_containers_of_one, false);
-    assert_eq!(options.sort_array_items, false);
+    assert!(options.trailing_commas);
+    assert!(!options.collapse_containers_of_one);
+    assert!(!options.sort_array_items);
 
     let options = FormatOptions {
         indent_by: 2,
@@ -1155,13 +1150,12 @@ fn test_options() {
                 PathOption::SortArrayItems(true),
             },
         },
-        ..Default::default()
     };
 
     assert_eq!(options.indent_by, 2);
-    assert_eq!(options.trailing_commas, false);
-    assert_eq!(options.collapse_containers_of_one, true);
-    assert_eq!(options.sort_array_items, true);
+    assert!(!options.trailing_commas);
+    assert!(options.collapse_containers_of_one);
+    assert!(options.sort_array_items);
 
     let path_options = options
         .options_by_path
@@ -1171,7 +1165,7 @@ fn test_options() {
         .get(&PathOption::TrailingCommas(true))
         .expect("Expected to find a PathOption::TrailingCommas setting")
     {
-        PathOption::TrailingCommas(trailing_commas) => assert_eq!(*trailing_commas, false),
+        PathOption::TrailingCommas(trailing_commas) => assert!(!(*trailing_commas)),
         _ => panic!("PathOption enum as key should return a value of the same type"),
     };
     match path_options
@@ -1179,7 +1173,7 @@ fn test_options() {
         .expect("Expected to find a PathOption::CollapseContainersOfOne setting")
     {
         PathOption::CollapseContainersOfOne(collapsed_container_of_one) => {
-            assert_eq!(*collapsed_container_of_one, false)
+            assert!(!(*collapsed_container_of_one))
         }
         _ => panic!("PathOption enum as key should return a value of the same type"),
     };
@@ -1187,7 +1181,7 @@ fn test_options() {
         .get(&PathOption::SortArrayItems(true))
         .expect("Expected to find a PathOption::SortArrayItems setting")
     {
-        PathOption::SortArrayItems(sort_array_items) => assert_eq!(*sort_array_items, true),
+        PathOption::SortArrayItems(sort_array_items) => assert!(*sort_array_items),
         _ => panic!("PathOption enum as key should return a value of the same type"),
     };
     match path_options
@@ -1238,7 +1232,7 @@ fn test_duplicated_key_in_subpath_options_is_ignored() {
             match path_options.get(&PathOption::TrailingCommas(true)) {
                 Some(path_option) => match path_option {
                     PathOption::TrailingCommas(trailing_commas) => {
-                        assert_eq!(*trailing_commas, false);
+                        assert!(!(*trailing_commas));
                     }
                     _ => panic!("PathOption enum as key should return a value of the same type"),
                 },
@@ -1247,7 +1241,7 @@ fn test_duplicated_key_in_subpath_options_is_ignored() {
             match path_options.get(&PathOption::CollapseContainersOfOne(true)) {
                 Some(path_option) => match path_option {
                     PathOption::CollapseContainersOfOne(collapsed_container_of_one) => {
-                        assert_eq!(*collapsed_container_of_one, false);
+                        assert!(!(*collapsed_container_of_one));
                     }
                     _ => panic!("PathOption enum as key should return a value of the same type"),
                 },
@@ -1256,7 +1250,7 @@ fn test_duplicated_key_in_subpath_options_is_ignored() {
             match path_options.get(&PathOption::SortArrayItems(true)) {
                 Some(path_option) => match path_option {
                     PathOption::SortArrayItems(sort_array_items) => {
-                        assert_eq!(*sort_array_items, true);
+                        assert!(*sort_array_items);
                     }
                     _ => panic!("PathOption enum as key should return a value of the same type"),
                 },
@@ -1880,7 +1874,7 @@ fn test_parsing_samples_does_not_crash() -> Result<(), std::io::Error> {
         let filename = entry.path().into_os_string().to_string_lossy().to_string();
         let mut buffer = String::new();
         println!("{}. Parsing: {} ...", count, filename);
-        if let Err(err) = fs::File::open(&entry.path())?.read_to_string(&mut buffer) {
+        if let Err(err) = fs::File::open(entry.path())?.read_to_string(&mut buffer) {
             println!("Ignoring failure to read the file into a string: {:?}", err);
             return Ok(());
         }


### PR DESCRIPTION
This was essentially just a run of `cargo clippy --fix --release --all-targets`, plus an addition to CI to run these clippy checks for pull requests and commits.

I also moved the constructor functions for `Primitive`, `Array`, and `Object` into value as `Value::new_primitive()`, `Value::new_array()`, and `Value::new_object()`, since those functions all returned `Value`.

There should be no functional library changes introduced in this PR, verified with `cargo test`.